### PR TITLE
Add docker image deployment to ECR

### DIFF
--- a/.github/workflows/bake.yaml
+++ b/.github/workflows/bake.yaml
@@ -3,6 +3,10 @@ name: 🍪 Bake Docker Image
 on:
   push:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   bake:
     name: 🍪 Bake Image
@@ -16,6 +20,14 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with: { go-version-file: go.mod, check-latest: true }
+      - name: Configure AWS credentials for ECR
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GHA_IAM_ROLE }}
+          role-session-name: temback-gha-docker-build-and-push
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
       - name: Login to Docker Hub # required for un-throttled pulls
         uses: docker/login-action@v3
         with:
@@ -32,5 +44,17 @@ jobs:
       - name: Build${{ startsWith(github.ref, 'refs/tags') && ' and Push' || '' }}
         env:
           REGISTRY: quay.io/tembo/temback
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           PUSH: "${{ startsWith(github.ref, 'refs/tags') }}"
-        run: make image
+        run: |
+          make image
+          if [ "$PUSH" = "true" ]; then
+            # Tag and push to ECR
+            docker tag $REGISTRY:${{ github.ref_name }} $ECR_REGISTRY:${{ github.ref_name }}
+            docker push $ECR_REGISTRY:${{ github.ref_name }}
+            # If this is a version tag, also update 'latest' tag
+            if [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              docker tag $REGISTRY:${{ github.ref_name }} $ECR_REGISTRY:latest
+              docker push $ECR_REGISTRY:latest
+            fi
+          fi


### PR DESCRIPTION
Adds pushing the docker image to a private ECR repo `387894460527.dkr.ecr.us-east-1.amazonaws.com/tembo-io/temback` - https://github.com/tembo-io/infrastructure/pull/925

Added `GHA_IAM_ROLE` and `ECR_REPOSITORY` to repository secrets.