### PR TITLE
Add `--dir` and add `.tar.gz` to uploaded object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,16 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [v0.1.1] — To Be Released
+## [v0.1.1] — 2025-04-24
 
 ### ⚡ Improvements
 
-New features and other improvements.
+*   Added the `--dir` option to specify the S3 subdirectory in which to upload
+    backups.
 
 ### 🪲 Bug Fixes
 
-Issues addressed.
-
-### 📔 Notes
-
-Security issues fixed, incompatible changes.
-
-### ⬆️ Dependency Updates
-
-Updates to third party dependencies.
-
-### 🏗️ Build Setup
-
-Changes to how Harpo is built and released.
-
-### 📚 Documentation
-
-Documentation improvements.
+*   Fixed the name of the file uploaded to S3 to end in `.tar.gz`.
 
   [v0.1.1]: https://github.com/tembo-io/temback/compare/v0.1.1...v0.1.1
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options
 
 *   `--name`: The name of the backup; required
 *   `--bucket`: Upload to the named S3 bucket
+*   `--dir`: Upload to the named S3 subdirectory
 *   `--compress`: Compress into a tarball (ignored with `--bucket`)
 *   `--host`: The Postgres host name; defaults to `PGHOST` if set
 *   `--user`: The Postgres username; defaults to `PGUSER` if set


### PR DESCRIPTION
The `--dir` option allows files to be uploaded to a "subdirectory" on S3. While testing it, I noticed that the uploaded files were missing the `.tar.gz` suffix, so fix that, too.

Set the release date for v0.1.1.