### PR TITLE
When backing up to S3 use `/tmp` directory to ensure we can write the dump to disk

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,11 @@ func newConfig() *backupConfig {
 		usage()
 	}
 
+	// If bucket is set, write to /tmp/<cfg.name> instead of just <cfg.name>
+	if cfg.bucket != "" {
+		cfg.name = filepath.Join("/tmp", cfg.name)
+	}
+
 	return cfg
 }
 


### PR DESCRIPTION
If you attempt to run `temback` in a Kubernetes Pod we should write the contents of the backup to `/tmp` instead of `/`.  This will prevent any issues writing the dump to local disk before uploading to S3

```
/var/lib/postgresql/data/temback --name tortuously-soaring-capuchin --bucket <s3 bucket> --dir <bucket path> --host localhost --user postgres --pass <password> --compress --clean
Backing up to tortuously-soaring-capuchin
mkdir tortuously-soaring-capuchin: read-only file system
```