### PR TITLE
Do not push to ECR

### DIFF
--- a/.github/workflows/bake.yaml
+++ b/.github/workflows/bake.yaml
@@ -47,8 +47,3 @@ jobs:
           REGISTRY: quay.io/tembo
           PUSH: ${{ startsWith(github.ref, 'refs/tags') }}
         run: make image
-      - name: Build${{ startsWith(github.ref, 'refs/tags') && ' and Push to ECR' || '' }}
-        env:
-          REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          PUSH: ${{ startsWith(github.ref, 'refs/tags') }}
-        run: make image


### PR DESCRIPTION
Since we no longer have a need to host the images in ECR we can remove the job that will push it to the container registry.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for building and pushing Docker images to Amazon ECR; images are now only built and pushed to Quay.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->